### PR TITLE
chore: Enable Renovate forkProcessing

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,3 +1,5 @@
 {
-  extends: ["github>cloudquery/.github//.github/renovate-go-default.json5"],
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>cloudquery/.github//.github/renovate-go-default.json5"],
+  "forkProcessing": "enabled"
 }


### PR DESCRIPTION
Enables forkProcessing so Renovate can process this forked repo and pin GitHub Actions to SHA digests.